### PR TITLE
RDKEMW-5799 - [RDKE] [RTK-VA-DEVICES] Audio is not heard through the bluetooth speaker.

### DIFF
--- a/source/process-capabilities_video.json
+++ b/source/process-capabilities_video.json
@@ -9,8 +9,13 @@
       "drop":""
    },
 
-    "parodus":{
+   "parodus":{
       "allow":"SYSTEM_GROUP,NETWORK_GROUP",
+      "drop":""
+   },
+
+   "audiocapturemgr":{
+      "allow":"CAP_DAC_OVERRIDE",
       "drop":""
    },
 
@@ -18,6 +23,7 @@
       "allow":"",
       "drop":""
    },
+
    "foo":{
       "allow":"SYSTEM_GROUP,NETWORK_GROUP",
       "drop":"CAP_DAC_OVERRIDE"


### PR DESCRIPTION
Reason for change: Updated the default process capability list to access the following paths.
    /dev/dma_heap/vo_non-ve
    /dev/dma_heap/vo_non-ve_uncached

Test Procedure: Verified the bluetooth audio in RTK VA platform.

Signed-off-by: thenmozhi_kathiravan@comcast.com