### PR TITLE
RDKB-63360 RDKEMW-13324 : Fix Coverity issues

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,13 +41,14 @@ AC_CHECK_LIB(cap, cap_init, LIBCAP_LIBS="-lcap"; has_linux_caps="yes", has_linux
 AC_SUBST(LIBCAP_LIBS)
 
 # Check for jsoncpp using pkg-config
-PKG_CHECK_MODULES([JSONCPP], [jsoncpp], [],
-  [AC_MSG_ERROR([jsoncpp not found. Install jsoncpp-devel])]
-)
+PKG_CHECK_MODULES([JSONCPP], [jsoncpp], [have_jsoncpp=yes], [
+  AC_MSG_WARN([jsoncpp not found via pkg-config, using default -ljsoncpp])
+  JSONCPP_CFLAGS=""
+  JSONCPP_LIBS="-ljsoncpp"
+  have_jsoncpp=yes
+])
 
 AC_SUBST(JSONCPP_CFLAGS)
-AC_SUBST(JSONCPP_LIBS)
-
 AC_SUBST(JSONCPP_LIBS)
 
 if test "x$has_linux_caps" = "xno"; then

--- a/source/utility.cpp
+++ b/source/utility.cpp
@@ -103,7 +103,7 @@ void populate_capabilities(Json::Value cfg_root, std::string caps_list, cap_valu
       if(cap_from_name(str_tmp.c_str(),&val) < 0 ){
         std::string group_list = cfg_root[str_tmp].asString();
         if(!group_list.empty()){
-           populate_capabilities(cfg_root,group_list,appcaps_list,cap_count);
+           populate_capabilities(cfg_root,std::move(group_list),appcaps_list,cap_count);
         }
       }
       else{
@@ -128,16 +128,16 @@ void get_capabilities(const char *processname, cap_user *appcaps)
 
     std::string default_caps = cfg_root["default"].asString();
     if(!default_caps.empty()){
-       populate_capabilities(cfg_root,default_caps,appcaps->caps_default,&appcaps->default_count);
+       populate_capabilities(cfg_root,std::move(default_caps),appcaps->caps_default,&appcaps->default_count);
     }
 
     std::string allow_caps = cfg_root[processname]["allow"].asString();
     if(!allow_caps.empty()){
-       populate_capabilities(cfg_root,allow_caps,appcaps->add,&appcaps->add_count);
+       populate_capabilities(cfg_root,std::move(allow_caps),appcaps->add,&appcaps->add_count);
     }
 
     std::string drop_caps = cfg_root[processname]["drop"].asString();
     if(!drop_caps.empty()){
-       populate_capabilities(cfg_root,drop_caps,appcaps->drop,&appcaps->drop_count);
+       populate_capabilities(cfg_root,std::move(drop_caps),appcaps->drop,&appcaps->drop_count);
     }
 }


### PR DESCRIPTION
Reason for change: Fix COPY_INSTEAD_OF_MOVE issue in rdk-libunpriv
Test Procedure: Reported coverity errors should be fixed
Priority: Medium
Risks: None